### PR TITLE
Lower bound on text

### DIFF
--- a/lens-aeson.cabal
+++ b/lens-aeson.cabal
@@ -30,7 +30,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: git://github.com/analytics/lens-aeson.git
+  location: git://github.com/lens/lens-aeson.git
 
 -- You can disable the doctests test suite with -f-test-doctests
 flag test-doctests


### PR DESCRIPTION
I have successfully built lens-aeson with `text 11.1.10`, and travis has `text 11.1.13` via apt-get. Lowering the text bound allows to use apt-get to install it on travis. I also fixed the source repository (it still pointed to `analytics/lens-aeson`)
