### PR TITLE
Update `text` dependency upper bound to 1.3.

### DIFF
--- a/lens-aeson.cabal
+++ b/lens-aeson.cabal
@@ -45,7 +45,7 @@ library
   build-depends:
     base                 >= 4.5       && < 5,
     lens                 >= 4.4       && < 4.5,
-    text                 >= 0.11.1.10 && < 1.2,
+    text                 >= 0.11.1.10 && < 1.3,
     vector               >= 0.9       && < 0.11,
     unordered-containers >= 0.2.3     && < 0.3,
     attoparsec           >= 0.10      && < 0.13,


### PR DESCRIPTION
text 1.2.0.0 was released on 9 Sept. `cabal test` runs successfully after this change.
