### PR TITLE
Bump aeson upper version bounds

### DIFF
--- a/lens-aeson.cabal
+++ b/lens-aeson.cabal
@@ -46,7 +46,7 @@ library
     unordered-containers >= 0.2.3     && < 0.3,
     attoparsec           >= 0.10      && < 0.14,
     bytestring           >= 0.9       && < 0.11,
-    aeson                >= 0.7.0.5   && < 0.9,
+    aeson                >= 0.7.0.5   && < 0.10,
     scientific           >= 0.3.2     && < 0.4
 
   exposed-modules:


### PR DESCRIPTION
Allow `lens-aeson` to build with the latest version of `aeson` (0.9.0.1).

The only API changes from this version bump relate to the `json`/`json'` parsers and `encodeToByteStringBuilder`, which `lens-aeson` doesn't seem to use.