### PR TITLE
Name the correct license in lens-aeson.cabal

### DIFF
--- a/lens-aeson.cabal
+++ b/lens-aeson.cabal
@@ -1,7 +1,7 @@
 name:          lens-aeson
 category:      Numeric
 version:       1.0.0.4
-license:       BSD3
+license:       MIT
 cabal-version: >= 1.8
 license-file:  LICENSE
 author:        Edward A. Kmett


### PR DESCRIPTION
LICENSE is the MIT license, not the BSD3 license.