### PR TITLE
Support upcoming aeson 0.10

### DIFF
--- a/lens-aeson.cabal
+++ b/lens-aeson.cabal
@@ -46,7 +46,7 @@ library
     unordered-containers >= 0.2.3     && < 0.3,
     attoparsec           >= 0.10      && < 0.14,
     bytestring           >= 0.9       && < 0.11,
-    aeson                >= 0.7.0.5   && < 0.10,
+    aeson                >= 0.7.0.5   && < 0.11,
     scientific           >= 0.3.2     && < 0.4
 
   exposed-modules:


### PR DESCRIPTION
Although it seems to have some minor API changes, these are mainly stuff that's long being deprecated:

https://github.com/bos/aeson/blob/master/changelog.md

The test suite still passes (with aeson 0.10), as long as I restrict the vector version to not face #18, which is a separate problem.

Thanks