### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/lens-aeson.cabal
+++ b/lens-aeson.cabal
@@ -62,7 +62,7 @@ library
     vector               >= 0.9       && < 0.13,
     unordered-containers >= 0.2.3     && < 0.3,
     attoparsec           >= 0.10      && < 0.14,
-    bytestring           >= 0.9       && < 0.11,
+    bytestring           >= 0.9       && < 0.12,
     aeson                >= 0.7.0.5   && < 1.6,
     scientific           >= 0.3.2     && < 0.4
 


### PR DESCRIPTION
Tested with
```cabal
packages: .

constraints:
  bytestring >= 0.11

source-repository-package
  type: git
  location: https://github.com/haskell/text
  tag: v1.2.4.1-rc1

source-repository-package
  type: git
  location: https://github.com/ekmett/lens

source-repository-package
  type: git
  location: https://github.com/haskell/attoparsec
```