### PR TITLE
Allow building with aeson-2.0.0.0

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,9 @@
+next [????.??.??]
+-----------------
+* Allow building with `aeson-2.0.0.0`.
+* Add `Index`, `IxValue`, `Ixed`, `At`, and `Each` instances for `KeyMap` if
+  building with `aeson-2.0.0.0` or later.
+
 1.1.1 [2021.02.17]
 ------------------
 * Allow building with `lens-5.*`.

--- a/lens-aeson.cabal
+++ b/lens-aeson.cabal
@@ -48,7 +48,9 @@ library
     unordered-containers >= 0.2.3     && < 0.3,
     attoparsec           >= 0.10      && < 0.15,
     bytestring           >= 0.9       && < 0.12,
-    aeson                >= 0.7.0.5   && < 1.6,
+    -- TODO: Eventually, we should bump the lower version bounds to >=2 so that
+    -- we can remove some CPP in Data.Aeson.Lens. See #38.
+    aeson                >= 0.7.0.5   && < 2.1,
     scientific           >= 0.3.2     && < 0.4
 
   exposed-modules:


### PR DESCRIPTION
`aeson-2.0.0.0` changes `Object`'s field from a `HashMap` to a new `KeyMap` type. This patch adapts `lens-aeson` to the new API. h/t to phadej/aeson-optics@ff31ca0578482df11002f0cde974ff51b8559e1c, on which I based this patch.

We may want to consider changing the type of `_Object` later (#38), but that should probably wait until we can depend on `aeson >= 2` unconditionally.

Fixes #37.