### PR TITLE
Use `KeyMap` instead of `HashMap` when dealing with `Object`s

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,24 @@
-next [????.??.??]
------------------
+1.2 [????.??.??]
+----------------
 * Require `aeson-2.0.*` and `lens-5.0.*` or greater.
+* Change the types of `_Object`, `key`, and `members`:
+
+  ```diff
+  _Object :: Prism' t (HashMap Text Value)
+  _Object :: Prism' t (KeyMap Value)
+
+  -key :: AsValue t => Text -> Traversal' t Value
+  +key :: AsValue t => Key  -> Traversal' t Value
+
+  -members :: AsValue t => IndexedTraversal' Text t Value
+  +members :: AsValue t => IndexedTraversal' Key  t Value
+  ```
+
+  This mirrors similar changes made in `aeson-2.0.*`, where the type of
+  `Object`'s field was changed from `HashMap Text Value` to `KeyMap Value`.
+* Add `Wrapped` and `Rewrapped` instances for `KeyMap`. These treat `KeyMap v`
+  as a wrapper around `[(Key, v)]`. The order in which the key-value pairs
+  appear in this list is not stable.
 
 1.1.3 [2021.11.16]
 ------------------

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+next [????.??.??]
+-----------------
+* Require `aeson-2.0.*` and `lens-5.0.*` or greater.
+
 1.1.3 [2021.11.16]
 ------------------
 * Drop support for pre-8.0 versions of GHC.

--- a/lens-aeson.cabal
+++ b/lens-aeson.cabal
@@ -39,15 +39,13 @@ source-repository head
 library
   build-depends:
     base                 >= 4.9       && < 5,
-    lens                 >= 4.4       && < 6,
+    lens                 >= 5.0       && < 6,
     text                 >= 0.11.1.10 && < 2.1,
     vector               >= 0.9       && < 0.13,
     unordered-containers >= 0.2.3     && < 0.3,
     attoparsec           >= 0.10      && < 0.15,
     bytestring           >= 0.9       && < 0.12,
-    -- TODO: Eventually, we should bump the lower version bounds to >=2 so that
-    -- we can remove some CPP in Data.Aeson.Lens. See #38.
-    aeson                >= 0.7.0.5   && < 2.1,
+    aeson                >= 2.0       && < 2.1,
     scientific           >= 0.3.2     && < 0.4
 
   exposed-modules:

--- a/lens-aeson.cabal
+++ b/lens-aeson.cabal
@@ -1,6 +1,6 @@
 name:          lens-aeson
 category:      Numeric
-version:       1.1.3
+version:       1.2
 license:       MIT
 cabal-version: >= 1.10
 license-file:  LICENSE

--- a/src/Data/Aeson/Lens.hs
+++ b/src/Data/Aeson/Lens.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -53,6 +52,8 @@ module Data.Aeson.Lens
 import Control.Applicative
 import Control.Lens
 import Data.Aeson
+import qualified Data.Aeson.Key    as Key
+import qualified Data.Aeson.KeyMap as KM
 import Data.Aeson.Parser (value)
 import Data.Attoparsec.ByteString.Lazy (maybeResult, parse)
 import Data.Scientific (Scientific)
@@ -68,11 +69,6 @@ import qualified Data.Text.Encoding as StrictText
 import qualified Data.Text.Lazy.Encoding as LazyText
 import Data.Vector (Vector)
 import Prelude hiding (null)
-
-#if MIN_VERSION_aeson(2,0,0)
-import qualified Data.Aeson.Key    as Key
-import qualified Data.Aeson.KeyMap as KM
-#endif
 
 -- $setup
 -- >>> import Control.Lens
@@ -297,15 +293,8 @@ class AsPrimitive t => AsValue t where
   -- >>> _Object._Wrapped # [("key" :: Text, _String # "value")] :: String
   -- "{\"key\":\"value\"}"
   _Object :: Prism' t (HashMap Text Value)
-  _Object = _Value.prism (Object . fwd) (\v -> case v of Object o -> Right (bwd o); _ -> Left v)
-    where
-#if MIN_VERSION_aeson(2,0,0)
-      fwd = KM.fromHashMapText
-      bwd = KM.toHashMapText
-#else
-      fwd = id
-      bwd = id
-#endif
+  _Object = _Value.prism (Object . KM.fromHashMapText)
+                         (\v -> case v of Object o -> Right (KM.toHashMapText o); _ -> Left v)
   {-# INLINE _Object #-}
 
   -- |
@@ -481,14 +470,7 @@ type instance Index Value = Text
 
 type instance IxValue Value = Value
 instance Ixed Value where
-  ix i f (Object o) = Object <$> ix (toKey i) f o
-    where
-#if MIN_VERSION_aeson(2,0,0)
-      toKey :: Text -> Key.Key
-      toKey = Key.fromText
-#else
-      toKey = id
-#endif
+  ix i f (Object o) = Object <$> ix (Key.fromText i) f o
   ix _ _ v          = pure v
   {-# INLINE ix #-}
 
@@ -498,7 +480,6 @@ instance Plated Value where
   plate _ xs = pure xs
   {-# INLINE plate #-}
 
-#if MIN_VERSION_aeson(2,0,0)
 type instance Index (KM.KeyMap v) = Key.Key
 type instance IxValue (KM.KeyMap v) = v
 
@@ -511,7 +492,6 @@ instance At (KM.KeyMap v) where
 instance Each (KM.KeyMap a) (KM.KeyMap b) a b where
   each = traversed
   {-# INLINE each #-}
-#endif
 
 ------------------------------------------------------------------------------
 -- Pattern Synonyms


### PR DESCRIPTION
In `aeson-2.0.*`, `Object`'s field is of type `KeyMap Value` rather than `HashMap Text Value`. Now that Stackage Nightly includes `aeson-2.0.*`, it's high time that we updated the `lens-aeson` API to mirror this change. This most notably affects the type of `_Object`, which also requires updating the types of `key` and `members` as a consequence.

In order to make the doctests continue to work, I found myself needing to add `Wrapped` and `Rewrapped` instances for `KeyMap`. In these instances, I treat `KeyMap v` as a wrapper around `[(Key, v)]`, where the order of the key-value pairs in the list is not stable.

Fixes https://github.com/lens/lens-aeson/issues/38.