### PR TITLE
Add an `IsKey` class

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,6 @@
 1.2 [????.??.??]
 ----------------
-* Require `aeson-2.0.*` and `lens-5.0.*` or greater.
+* Require `aeson-2.0.2.*` and `lens-5.0.*` or greater.
 * Change the types of `_Object`, `key`, and `members`:
 
   ```diff
@@ -26,6 +26,8 @@
 * Add `Wrapped` and `Rewrapped` instances for `KeyMap`. These treat `KeyMap v`
   as a wrapper around `[(Key, v)]`. The order in which the key-value pairs
   appear in this list is not stable.
+* Add an `IsKey` class, whose method `_Key` is an `Iso` for converting values
+  to and from a `Key`.
 
 1.1.3 [2021.11.16]
 ------------------

--- a/lens-aeson.cabal
+++ b/lens-aeson.cabal
@@ -41,11 +41,12 @@ library
     base                 >= 4.9       && < 5,
     lens                 >= 5.0       && < 6,
     text                 >= 0.11.1.10 && < 2.1,
+    text-short           >= 0.1.4     && < 0.2,
     vector               >= 0.9       && < 0.13,
     unordered-containers >= 0.2.3     && < 0.3,
     attoparsec           >= 0.10      && < 0.15,
     bytestring           >= 0.9       && < 0.12,
-    aeson                >= 2.0       && < 2.1,
+    aeson                >= 2.0.2     && < 2.1,
     scientific           >= 0.3.2     && < 0.4
 
   exposed-modules:


### PR DESCRIPTION
The `_Key` `Iso` will make it easier to convert to/from `_Key`s in idiomatic `lens` code. Inspired by https://github.com/lens/lens-aeson/pull/42#discussion_r820667720.