### PR TITLE
Decode `ByteString`s to UTF-8 leniently

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,11 @@
+next [????.??.??]
+-----------------
+* Change the `IsKey` instances for `ByteString`s to use
+  `decodeUtf8With lenientDecode` instead of `decodeUtf8`. While these `IsKey`
+  instances are meant to used for interoperability with `aeson` values that
+  are UTF-8–encoded, using `decodeUtf8With lenientDecode` at least ensures
+  that converting a non–UTF-8–encoded `ByteString` will not crash.
+
 1.2 [2022.03.19]
 ----------------
 * Require `aeson-2.0.2.*` and `lens-5.0.*` or greater.


### PR DESCRIPTION
While JSON values are assumed to be UTF-8–encoded, there are some exposed functions that can be provided non–UTF-8–encoded inputs, such as the `_Key` implementations for `ByteString`s. Just in case a user provides inputs to these functions that are not non–UTF-8–encoded, this patch replaces the use of `decodeUtf8` with `decodeUtf8With lenientDecode`. That way, rather than having these inputs crash the program, the offending characters will simply be replaced with Unicode replacement characters.

Fixes #48.